### PR TITLE
feat: add version and ignore validation err flags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: "{{ incpatch .Version }}-snapshot"
 changelog:
   sort: asc
   filters:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tidy:
 	@go mod tidy
 
 build:
-	@go build -o dist/bin/schemacheck
+	@goreleaser build --rm-dist --skip-validate --snapshot
 
 release:
 	@goreleaser build --rm-dist 


### PR DESCRIPTION
Adds a version flag that will return the version of schemacheck. The
version is set automatically by GoReleaser upon build through a default
ldflag. Adds a ignore-val-err flag that will warn and exit with exit
code 0 instead of 1. This exit only affects when the document exists but
doesn't return valid according to the schema. May be useful for when you want a
soft failure for historical systems.