### PR TITLE
feat(build): update make build command, add install, update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,34 @@ INSTALL_PATH ?= /usr/local/bin
 BIN_NAME ?= schemacheck
 BINDIR := $(CURDIR)/bin
 
-.PHONY: tidy build test checks clean release
-
 default: build
 
+.PHONY:  tidy
 tidy:
 	@go mod tidy
 
+.PHONY: build
 build:
-	@goreleaser build --rm-dist --skip-validate --snapshot
+	@goreleaser build \
+		--rm-dist \
+		--skip-validate \
+		--single-target \
+		--output dist/$(BIN_NAME)
 
+.PHONY: install
+install: build
+	@install dist/$(BIN_NAME) $(INSTALL_PATH)/$(BIN_NAME)
+	@schemacheck --version
+
+.PHONY: release
 release:
 	@goreleaser build --rm-dist 
 
+.PHONY: test
 test:
 	@go test -v
 
+.PHONY: checks
 checks:
 	@go fmt ./...
 	@go vet ./...

--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ find . -type f -name "*.json" -exec ./dist/bin/schemacheck -s test_data/schema.j
 ```
 
 ## Install
-There are a few different methods to install `schemacheck`.
+There are a couple different methods to install `schemacheck`.
 
-### Via `go` (Recommended)
-* Run `go install github.com/adrielp/schemacheck`
+### Preferred methods
+* Via `go` (recommended): `go install github.com/adrielp/schemacheck`
+* Via `brew`: `brew install schemacheck` (Mac / Linux)
+
 
 ### Mac/Linux during local development
-* Clone down this repository and run `make build`
-* Install a binary for your platform from `dist/bin` locally to a path
-
+* Clone down this repository and run `make install`
 
 ### Windows
-There's a binary for that, but it's not directly supported or tested because #windows
+There's a binary for that, but it's not directly supported or tested because `#windows`
 
 ## Getting Started
 ### Prereqs


### PR DESCRIPTION
Changes the way schemacheck is built through the make build command and
leverages a single target build for local builds. Adds the make install
command to install the local build and updates documentation
accordingly.